### PR TITLE
Delete column & all tasks. Fixed Task delete response.

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -211,12 +211,12 @@ function App() {
             {/* map through columns array and render each column with the title */}
             {columns.map((item, i) => {
               return (
-                <Column title={item.column_name} key={i} id={i}>
+                <Column title={item.column_name} key={i} id={item.id_column}>
                   {/* inside each column, map through the cards and render each one that matches the column index */}
                   {tasks !== null &&
                     tasks.map(
                       (card) =>
-                        card.id_column === i && (
+                        card.id_column === item.id_column && (
                           <CardComponent
                             id={card.id_task}
                             title={card.task_title}

--- a/client/src/components/CardComponent.js
+++ b/client/src/components/CardComponent.js
@@ -15,8 +15,7 @@ import {
   Input,
 } from 'semantic-ui-react';
 import ReactMarkdown from 'react-markdown';
-// import { IoIosArrowDropright } from 'react-icons/io';
-// import { FaEllipsisV } from 'react-icons/fa';
+import Fade from 'react-reveal/Fade';
 import DropMenu from './DropMenu';
 import { AutoContext } from '../AutoContext';
 
@@ -141,6 +140,7 @@ function CardComponent(props) {
   };
 
   return (
+    <Fade bottom>
     <Card className="card">
       <Card.Body>
         <Card.Title>
@@ -291,6 +291,7 @@ function CardComponent(props) {
         )}
       </Card.Footer>
     </Card>
+    </Fade>
   );
 }
 export default CardComponent;

--- a/client/src/components/DropMenu.js
+++ b/client/src/components/DropMenu.js
@@ -36,13 +36,15 @@ function DropMenu(props) {
   };
 
   const handleDeleteCard = () => {
-    axios
-      .delete(`/api/task/delete/${context[10].project}`, {
-        data: { id_task: props.id },
-      })
-      .then((response) => {
-        context[7](response.data);
-      });
+    if (window.confirm('Are you sure you want to delete this task?')) {
+      axios
+        .delete(`/api/task/delete/${context[10].project}`, {
+          data: { id_task: props.id },
+        })
+        .then((response) => {
+          context[7](response.data);
+        });
+    }
   };
 
   const editCard = () => {

--- a/client/src/components/DropMenu.js
+++ b/client/src/components/DropMenu.js
@@ -6,7 +6,7 @@ import { AutoContext } from '../AutoContext';
 function DropMenu(props) {
   const context = useContext(AutoContext);
 
-  const cascadeDelete = () => {
+  const cascadeDelete = (c) => {
     // delete column from db
     axios
     .delete(`/api/columns/?proj=${context[10].project}`, {
@@ -14,13 +14,16 @@ function DropMenu(props) {
     })
     .then((res) => context[3](res.data));
     // delete tasks in column from db
-    axios
-    .delete(`/api/task/cdelete/${context[10].project}`, {
-      data: { id_column: props.id },
-    })
-    .then((response) => {
-      context[7](response.data);
-    });
+    if (c !== 'column') {
+      console.log('test')
+      axios
+      .delete(`/api/task/cdelete/${context[10].project}`, {
+        data: { id_column: props.id },
+      })
+      .then((response) => {
+        context[7](response.data);
+      });
+    }
   }
 
   const handleDeleteColumn = () => {
@@ -30,7 +33,7 @@ function DropMenu(props) {
         cascadeDelete();
       }
     } else {
-      cascadeDelete();
+      cascadeDelete('column');
     }
     
   };

--- a/client/src/components/DropMenu.js
+++ b/client/src/components/DropMenu.js
@@ -7,11 +7,20 @@ function DropMenu(props) {
   const context = useContext(AutoContext);
 
   const handleDeleteColumn = () => {
-    axios
+    if (window.confirm('This will delete all tasks in this column. Are you sure?')) {
+      axios
       .delete(`/api/columns/?proj=${context[10].project}`, {
-        data: { id_place: props.id },
+        data: { id_column: props.id },
       })
       .then((res) => context[3](res.data));
+      axios
+      .delete(`/api/task/cdelete/${context[10].project}`, {
+        data: { id_column: props.id },
+      })
+      .then((response) => {
+        context[7](response.data);
+      });
+    }
   };
 
   const handleDeleteCard = () => {

--- a/client/src/components/DropMenu.js
+++ b/client/src/components/DropMenu.js
@@ -6,21 +6,33 @@ import { AutoContext } from '../AutoContext';
 function DropMenu(props) {
   const context = useContext(AutoContext);
 
+  const cascadeDelete = () => {
+    // delete column from db
+    axios
+    .delete(`/api/columns/?proj=${context[10].project}`, {
+      data: { id_column: props.id },
+    })
+    .then((res) => context[3](res.data));
+    // delete tasks in column from db
+    axios
+    .delete(`/api/task/cdelete/${context[10].project}`, {
+      data: { id_column: props.id },
+    })
+    .then((response) => {
+      context[7](response.data);
+    });
+  }
+
   const handleDeleteColumn = () => {
-    if (window.confirm('This will delete all tasks in this column. Are you sure?')) {
-      axios
-      .delete(`/api/columns/?proj=${context[10].project}`, {
-        data: { id_column: props.id },
-      })
-      .then((res) => context[3](res.data));
-      axios
-      .delete(`/api/task/cdelete/${context[10].project}`, {
-        data: { id_column: props.id },
-      })
-      .then((response) => {
-        context[7](response.data);
-      });
+    // if tasks are in column, confirm with user
+    if (context[6].filter((task) => task.id_column === props.id).length > 0) {
+      if (window.confirm('This will delete all tasks in this column. Are you sure?')) {
+        cascadeDelete();
+      }
+    } else {
+      cascadeDelete();
     }
+    
   };
 
   const handleDeleteCard = () => {

--- a/client/src/components/ProjectView.js
+++ b/client/src/components/ProjectView.js
@@ -3,7 +3,7 @@ import Fade from 'react-reveal/Fade';
 
 export default function ProjectView(props) {
   return (
-    <Fade>
+    <Fade duration={2000}>
       <div className="project-view">{props.children}</div>
     </Fade>
   );

--- a/client/src/components/modals/TaskModal.js
+++ b/client/src/components/modals/TaskModal.js
@@ -38,7 +38,7 @@ export default function TaskModal(props) {
     start_date: null,
     end_date: null,
     complete: false,
-    created_by: context[8].id_user,
+    created_by: context[8].username,
     id_label1: null,
     id_label2: null,
     id_label3: null,

--- a/client/src/components/modals/TaskModal.js
+++ b/client/src/components/modals/TaskModal.js
@@ -38,7 +38,7 @@ export default function TaskModal(props) {
     start_date: null,
     end_date: null,
     complete: false,
-    created_by: context[10].project,
+    created_by: context[8].id_user,
     id_label1: null,
     id_label2: null,
     id_label3: null,

--- a/client/src/styles/style.css
+++ b/client/src/styles/style.css
@@ -327,8 +327,10 @@ label {
   font-size: 9px;
   min-height: 0;
   height: 14px;
+  max-height: fit-content;
+  width: fit-content;
+  margin-left: auto;
   padding: 0;
-  text-align: right;
 }
 
 .card-footer {
@@ -338,6 +340,14 @@ label {
   align-items: center;
   height: fit-content;
   flex-wrap: wrap;
+}
+
+code {
+  background-color: rgb(230, 230, 230);
+  color: rgb(0, 156, 0);
+  border-radius: 5px;
+  padding: 1px 3px;
+  font-size: 13px;
 }
 
 .label {

--- a/controllers/apiRoutes/columns.js
+++ b/controllers/apiRoutes/columns.js
@@ -146,7 +146,7 @@ router.delete('/', function (req, res) {
     db.Columns.destroy({
       where: {
         id_project: req.query.proj,
-        id_place: req.body.id_place,
+        id_column: req.body.id_column,
       },
     })
       // update place ids

--- a/controllers/apiRoutes/task.js
+++ b/controllers/apiRoutes/task.js
@@ -7,22 +7,7 @@ router.get('/get/all/:proj_id', function (req, res) {
   db.Task.findAll({
     where: { id_project: req.params.proj_id },
   }).then((allTasks) => {
-    // const createdBys = allTasks.map(
-    //   (user) => user.dataValues.created_by,
-    // );
-    // db.User.findAll({
-    //   where: { id_user: { [Op.in]: createdBys } },
-    // }).then((users) => {
-    //   users.forEach((user) => {
-    //     allTasks.forEach((task) => {
-    //       if (task.dataValues.created_by === user.dataValues.id_user) {
-    //         task.dataValues.created_by = user.dataValues.username
-    //       }
-    //     });
-    //   });
-    //   console.log(allTasks);
     res.json(allTasks);
-    // });
   });
 });
 // find task to render in task modal

--- a/controllers/apiRoutes/task.js
+++ b/controllers/apiRoutes/task.js
@@ -7,22 +7,22 @@ router.get('/get/all/:proj_id', function (req, res) {
   db.Task.findAll({
     where: { id_project: req.params.proj_id },
   }).then((allTasks) => {
-    const createdBys = allTasks.map(
-      (user) => user.dataValues.created_by,
-    );
-    db.User.findAll({
-      where: { id_user: { [Op.in]: createdBys } },
-    }).then((users) => {
-      users.forEach((user) => {
-        allTasks.forEach((task) => {
-          if (task.dataValues.created_by === user.dataValues.id_user) {
-            task.dataValues.created_by = user.dataValues.username
-          }
-        });
-      });
-      console.log(allTasks);
-      res.json(allTasks);
-    });
+    // const createdBys = allTasks.map(
+    //   (user) => user.dataValues.created_by,
+    // );
+    // db.User.findAll({
+    //   where: { id_user: { [Op.in]: createdBys } },
+    // }).then((users) => {
+    //   users.forEach((user) => {
+    //     allTasks.forEach((task) => {
+    //       if (task.dataValues.created_by === user.dataValues.id_user) {
+    //         task.dataValues.created_by = user.dataValues.username
+    //       }
+    //     });
+    //   });
+    //   console.log(allTasks);
+    res.json(allTasks);
+    // });
   });
 });
 // find task to render in task modal

--- a/models/Task.js
+++ b/models/Task.js
@@ -23,7 +23,7 @@ module.exports = function (sequelize, DataTypes) {
         type: DataTypes.BOOLEAN,
         allowNull: false,
       },
-      created_by: { type: DataTypes.INTEGER, allowNull: false },
+      created_by: { type: DataTypes.STRING(50), allowNull: false, len: [2,16] },
     },
     { freezeTableName: true },
   );


### PR DESCRIPTION
**Back End**
- created cascade delete route for when column is deleted. Deletes all tasks that have a matching column id
- fixed Task delete response to include only current project tasks, not all tasks in the table
- changed Task model to have username instead of id in the 'created_by' field, reducing the logic to retrieve the created by username for displaying on tasks on the front end

**Front End**
- deletion of column (only if tasks exists) and task now prompts user with a confirm box
- added fade animation to tasks. fade up from bottom of column on load.
- task posts now use the username from context

close #87 